### PR TITLE
Separate fruit pie color (Aesthetic)

### DIFF
--- a/toontown/battle/BattleProps.py
+++ b/toontown/battle/BattleProps.py
@@ -197,6 +197,7 @@ Props = ((5, 'partyBall', 'partyBall'),
   'SZ_splashdown-chan'))
 CreampieColor = VBase4(250.0 / 255.0, 241.0 / 255.0, 24.0 / 255.0, 1.0)
 FruitpieColor = VBase4(55.0 / 255.0, 40.0 / 255.0, 148.0 / 255.0, 1.0)
+FruittartColor = VBase4(155.0 / 255.0, 120.0 / 255.0, 110.0 / 255.0, 1.0)
 BirthdayCakeColor = VBase4(253.0 / 255.0, 119.0 / 255.0, 220.0 / 255.0, 1.0)
 SnowballColor = VBase4(1.0, 1.0, 1.0, 1.0)
 Splats = {'tart': (0.3, FruitpieColor),
@@ -302,6 +303,7 @@ class PropPool:
             self.props[name].setScale(0.5)
         elif name == 'fruitpie':
             self.props[name].setScale(0.75)
+            self.props[name].setColor(FruittartColor)
         elif name == 'double-windsor':
             self.props[name].setScale(1.5)
         elif name[:6] == 'splat-':


### PR DESCRIPTION
Fruit Tart color used for separation from other tart gags. Purely aesthetic, no real gameplay interaction besides a color swap.
In game view of fruit tart after patch : http://puu.sh/f62LR/7272752206.jpg
