### PR TITLE
Polish: Correcting margin cell alignment.

### DIFF
--- a/toontown/chat/WhisperPopup.py
+++ b/toontown/chat/WhisperPopup.py
@@ -327,6 +327,11 @@ class WhisperPopup(Clickable2d, MarginVisible):
         self.draw()
 
         left, right, bottom, top = self.textNode.getFrameActual()
+        left -= self.chatBalloon.BALLOON_X_PADDING
+        right += self.chatBalloon.BALLOON_X_PADDING
+        bottom -= self.chatBalloon.BALLOON_Z_PADDING
+        top += self.chatBalloon.BALLOON_Z_PADDING
+
         if self.cell in base.bottomCells:
             # Move the origin to the bottom center of the chat balloon:
             origin = self.contents.getRelativePoint(

--- a/toontown/nametag/Nametag2d.py
+++ b/toontown/nametag/Nametag2d.py
@@ -288,10 +288,18 @@ class Nametag2d(Nametag, Clickable2d, MarginVisible):
             nodePath = self.chatBalloon.textNodePath
 
             left, right, bottom, top = self.chatTextNode.getFrameActual()
+            left -= self.chatBalloon.BALLOON_X_PADDING
+            right += self.chatBalloon.BALLOON_X_PADDING
+            bottom -= self.chatBalloon.BALLOON_Z_PADDING
+            top += self.chatBalloon.BALLOON_Z_PADDING
         elif self.panel is not None:
             nodePath = self.textNodePath
 
             left, right, bottom, top = self.textNode.getFrameActual()
+            left -= self.PANEL_X_PADDING
+            right += self.PANEL_X_PADDING
+            bottom -= self.PANEL_Z_PADDING
+            top += self.PANEL_Z_PADDING
 
             # Compensate for the arrow:
             bottom -= self.ARROW_SCALE


### PR DESCRIPTION
Hello!

It's wonderful to see that the Toontown Infinite code hasn't gone to waste (and that Chan is still sweating, heh). Prior to Toontown Infinite's closing, I had a few issues with the game's overall quality... well, a lot of issues... but nevertheless, this is one of the issues that I would like to fix (as fixing it took less time than writing this rather long synopsis, and oh how Kevin, Mark, and Chan know I must have everything be perfect).

Let me explain the problem. It's quite simple, and probably not noticed by many:

Currently, the margin cells are being aligned by their contents' text frame:
![example1](https://cloud.githubusercontent.com/assets/6107224/6020763/ce20215e-ab7d-11e4-89c8-5102cff48411.png)

This results in some slightly unaligned content, which in my opinion looks ugly. The **correct** behavior would be to also take into account the contents' padding (as chat balloons, nametags, and whisper popups all have a set in stone padding):
![example2](https://cloud.githubusercontent.com/assets/6107224/6020765/d3f74bde-ab7d-11e4-926a-229eb09192fa.png)
